### PR TITLE
Fix precision in vector_angle()

### DIFF
--- a/src/SHARPlib/winds.cpp
+++ b/src/SHARPlib/winds.cpp
@@ -42,7 +42,7 @@ float vector_angle(float u_comp, float v_comp) {
 #endif
     if ((u_comp == 0) && (v_comp == 0)) return 0;
 
-    float wind_direction = std::atan2(-1 * u_comp, -1 * v_comp) * (180.0 / PI);
+    float wind_direction = std::atan2(-1.0 * u_comp, -1.0 * v_comp) * (180.0 / PI);
     if (wind_direction < 0) wind_direction += 360.0;
     if (wind_direction < TOL) wind_direction = 0;
     return wind_direction;


### PR DESCRIPTION
I ran the unit tests, and I noticed these two wind tests were failing on my M1 Macbook. 

```cpp
sharp::WindComponents s_wind = {0.0, 10.0};
// ...
CHECK(sharp::vector_angle(s_wind.u, s_wind.v) == 180.0);
// ...
auto s_vect = sharp::components_to_vector(s_wind.u, s_wind.v);
// ...
CHECK(s_vect.direction == 180.0);
```

Both of these involve calling `sharp::vector_angle()` and getting an answer that should be 180 degrees, but the outputs were wrong by about 1.5e-5 degrees. `sharp::vector_angle()` calls `std::atan2()`, but it does so with float arguments. This causes the compiler to use the float-overloaded version of `std::atan2()`, which I think causes precision issues when the output is at ±π. 

So the fix is to promote the arguments to doubles, which causes the compiler to use the double-overloaded version of `std::atan2()`, which fixes the precision issues. (Based on other functions in there, I suspect this is what you meant to do, anyway.)