### PR TITLE
Fix versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,16 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(GitVersion)
 get_version_from_git()
 
+if(NOT DEFINED PROJECT_VERSION_MAJOR)
+  if(DEFINED PROJECT_VERSION)
+      # Extract major, minor, patch from PROJECT_VERSION
+      string(REGEX REPLACE "^([0-9]+)\\.([0-9]+)\\.([0-9]+).*" "\\1;\\2;\\3" VERSION_LIST ${PROJECT_VERSION})
+      list(GET VERSION_LIST 0 PROJECT_VERSION_MAJOR)
+      list(GET VERSION_LIST 1 PROJECT_VERSION_MINOR)
+      list(GET VERSION_LIST 2 PROJECT_VERSION_PATCH)
+  endif()
+endif()
+
 configure_file(
     ${CMAKE_SOURCE_DIR}/include/SHARPlib/version.h.in
     ${CMAKE_SOURCE_DIR}/include/SHARPlib/version.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,16 +5,16 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(GitVersion)
-get_version_from_git()
 
-if(NOT DEFINED PROJECT_VERSION_MAJOR)
-  if(DEFINED PROJECT_VERSION)
-      # Extract major, minor, patch from PROJECT_VERSION
-      string(REGEX REPLACE "^([0-9]+)\\.([0-9]+)\\.([0-9]+).*" "\\1;\\2;\\3" VERSION_LIST ${PROJECT_VERSION})
-      list(GET VERSION_LIST 0 PROJECT_VERSION_MAJOR)
-      list(GET VERSION_LIST 1 PROJECT_VERSION_MINOR)
-      list(GET VERSION_LIST 2 PROJECT_VERSION_PATCH)
-  endif()
+if(NOT DEFINED SKBUILD_PROJECT_VERSION)
+    get_version_from_git()
+else()
+    # Extract major, minor, patch from PROJECT_VERSION
+    message(${SKBUILD_PROJECT_VERSION})
+    string(REGEX REPLACE "^([0-9]+)\\.([0-9]+)\\.([0-9]+).*" "\\1;\\2;\\3" VERSION_LIST ${SKBUILD_PROJECT_VERSION})
+    list(GET VERSION_LIST 0 PROJECT_VERSION_MAJOR)
+    list(GET VERSION_LIST 1 PROJECT_VERSION_MINOR)
+    list(GET VERSION_LIST 2 PROJECT_VERSION_PATCH)
 endif()
 
 configure_file(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ sdist.include = ["src/nanobind/_version.py"]
 
 [tool.scikit-build.cmake.define]
 BUILD_PYBIND = true
-PROJECT_VERSION = "{{version}}"
 
 [tool.setuptools_scm]  # Section required
 write_to = "src/nanobind/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ sdist.include = ["src/nanobind/_version.py"]
 
 [tool.scikit-build.cmake.define]
 BUILD_PYBIND = true
+PROJECT_VERSION = "{{version}}"
 
 [tool.setuptools_scm]  # Section required
 write_to = "src/nanobind/_version.py"


### PR DESCRIPTION
Some of how I was handling versioning between both Python and CMake wasn't working well when making a conda recipe. When building from pypi, setuptools_scm could successfully get the version for Python, but CMake would fail because it gets its version info from git tags (which aren't available in the tar file).

This change reads SKBUILD_PROJECT_VERSION, and if its set, uses that. If the environment variable is not set, it uses git tags. 