### PR TITLE
Ensure submodule dependencies are packaged by sdist

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -69,6 +69,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+          fetch-tags: 'true'
+          fetch-depth: 0
+
+      - name: Change submodule URLs to HTTPS 
+        run: |
+          git submodule foreach '
+            git config submodule.$name.url https://github.com/$urlPath
+          '
+      - name: Submodules and Dependencies
+        run: |
+          git config --global --add safe.directory ${{ github.workspace }} 
+          git submodule update --init --recursive
 
       - name: Build sdist
         run: pipx run build --sdist

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Python CI (Linux, MacOS, Windows)](https://github.com/keltonhalbert/SHARPlib/actions/workflows/python.yml/badge.svg)](https://github.com/keltonhalbert/SHARPlib/actions/workflows/python.yml)
 [![Build Wheels](https://github.com/keltonhalbert/SHARPlib/actions/workflows/wheels.yml/badge.svg)](https://github.com/keltonhalbert/SHARPlib/actions/workflows/wheels.yml)
 [![Build Docs](https://github.com/keltonhalbert/SHARPlib/actions/workflows/doxygen-gh-pages.yml/badge.svg)](https://github.com/keltonhalbert/SHARPlib/actions/workflows/doxygen-gh-pages.yml)
+[![PyPI - Version](https://img.shields.io/pypi/v/SHARPlib)](https://pypi.org/project/SHARPlib/)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/SHARPlib)
 
 
 **Sounding and Hodograph Analysis and Research Program (SHARP)** C++ library for conducting analysis of atmospheric sounding profiles. Based on the NSHARP routines written by John Hart and Rich Thompson at the NWS Storm Prediction Center in Norman, Oklahoma. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ cmake.version = ">=3.15"
 cmake.build-type = "Release"
 build-dir = "build/{wheel_tag}"
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
-sdist.include = ["src/nanobind/_version.py"]
+sdist.include = ["src/nanobind/_version.py", "external/**"]
 
 [tool.scikit-build.cmake.define]
 BUILD_PYBIND = true


### PR DESCRIPTION
In continuing to flesh out the build pipeline for conda, it became a problem that submodules were not being packaged in the sdist. So, this should remedy that. 