### PR TITLE
BUGFIX: 1.0.1

### DIFF
--- a/include/SHARPlib/parcel.h
+++ b/include/SHARPlib/parcel.h
@@ -322,10 +322,8 @@ struct Parcel {
         const LayerIndex dry_idx = get_layer_index(dry_lyr, pressure_arr, N);
         const LayerIndex sat_idx = get_layer_index(sat_lyr, pressure_arr, N);
 
-        // zero out any residual buoyancy from
-        // other parcels that may have been lifted
         for (std::ptrdiff_t k = 0; k < dry_idx.kbot; ++k) {
-            pcl_vtmpk_arr[k] = 0.0f;
+            pcl_vtmpk_arr[k] = MISSING;
         }
 
         // Virtual potential temperature (Theta-V)

--- a/src/SHARPlib/interp.cpp
+++ b/src/SHARPlib/interp.cpp
@@ -112,93 +112,75 @@ float interp_pressure(const float pressure_val, const float pressure_arr[],
     return lerp(data_bot, data_top, dp_norm);
 }
 
-float find_first_pressure(const float data_val, const float *pressure_arr,
-                          const float *data_arr, const std::ptrdiff_t N) {
+float find_first_pressure(const float data_val, const float pressure_arr[],
+                          const float data_arr[], const std::ptrdiff_t N) {
+    std::ptrdiff_t k_start = 0;
 #ifndef NO_QC
     if (data_val == MISSING) {
         return MISSING;
     }
+    for (; k_start < N; ++k_start) {
+        if (data_arr[k_start] != MISSING) break;
+    }
 #endif
 
-    float val0, val1;
-    for (std::ptrdiff_t k = 1; k < N; ++k) {
-        val0 = data_arr[k - 1];
-        val1 = data_arr[k];
+    for (std::ptrdiff_t k = k_start + 1; k < N; ++k) {
+        float val0 = data_arr[k_start];
+        float val1 = data_arr[k];
+#ifndef NO_QC
+        if (val1 == MISSING) continue;
+#endif
+        if (val0 == data_val) return pressure_arr[k_start];
+        if (val1 == data_val) return pressure_arr[k];
 
-        if (val0 == data_val) {
-            return pressure_arr[k - 1];
-        }
-        if (val1 == data_val) {
-            return pressure_arr[k];
-        }
-
-        // data are decreasing
-        if ((val0 > data_val) && (val1 < data_val)) {
-            const float logp_bot = std::log10(pressure_arr[k - 1]);
-            const float logp_top = std::log10(pressure_arr[k]);
-
-            const float d_norm = (val0 - data_val) / (val0 - val1);
-
-            // return the linear interpolation
-            return std::pow(10, lerp(logp_bot, logp_top, d_norm));
-        }
-
-        // data are increasing
-        if ((val0 < data_val) && (val1 > data_val)) {
-            const float logp_bot = std::log10(pressure_arr[k - 1]);
+        if ((data_val - val0) * (data_val - val1) < 0) {
+            const float logp_bot = std::log10(pressure_arr[k_start]);
             const float logp_top = std::log10(pressure_arr[k]);
 
             const float d_norm = (data_val - val0) / (val1 - val0);
 
-            // return the linear interpolation
             return std::pow(10, lerp(logp_bot, logp_top, d_norm));
         }
+
+        k_start = k;
     }
 
     return MISSING;
 }
 
-float find_first_height(const float data_val, const float *height_arr,
-                        const float *data_arr, const std::ptrdiff_t N) {
+float find_first_height(const float data_val, const float height_arr[],
+                        const float data_arr[], const std::ptrdiff_t N) {
+    std::ptrdiff_t k_start = 0;
 #ifndef NO_QC
     if (data_val == MISSING) {
         return MISSING;
     }
+    for (; k_start < N; ++k_start) {
+        if (data_arr[k_start] != MISSING) break;
+    }
 #endif
 
-    float val0, val1;
     for (std::ptrdiff_t k = 1; k < N; ++k) {
-        val0 = data_arr[k - 1];
-        val1 = data_arr[k];
+        float val0 = data_arr[k_start];
+        float val1 = data_arr[k];
+#ifndef NO_QC
+        if (val1 == MISSING) continue;
+#endif
+        if (val0 == data_val) return height_arr[k_start];
+        if (val1 == data_val) return height_arr[k];
 
-        if (val0 == data_val) {
-            return height_arr[k - 1];
-        }
-        if (val1 == data_val) {
-            return height_arr[k];
-        }
-
-        // data are decreasing
-        if ((val0 > data_val) && (val1 < data_val)) {
-            const float hght_bot = height_arr[k - 1];
-            const float hght_top = height_arr[k];
-
-            const float d_norm = (val0 - data_val) / (val0 - val1);
-
-            // return the linear interpolation
-            return lerp(hght_bot, hght_top, d_norm);
-        }
-
-        // data are increasing
-        if ((val0 < data_val) && (val1 > data_val)) {
-            const float hght_bot = height_arr[k - 1];
+        // will have a negative sign if levels straddle
+        // the point being searched for
+        if ((data_val - val0) * (data_val - val1) < 0) {
+            const float hght_bot = height_arr[k_start];
             const float hght_top = height_arr[k];
 
             const float d_norm = (data_val - val0) / (val1 - val0);
 
-            // return the linear interpolation
             return lerp(hght_bot, hght_top, d_norm);
         }
+
+        k_start = k;
     }
 
     return MISSING;

--- a/src/SHARPlib/parcel.cpp
+++ b/src/SHARPlib/parcel.cpp
@@ -79,17 +79,17 @@ void Parcel::find_lfc_el(const float pres_arr[], const float hght_arr[],
     PressureLayer sat_lyr = {this->lcl_pressure, pres_arr[N - 1]};
     LayerIndex lyr_idx = get_layer_index(sat_lyr, pres_arr, N);
 
-    float lyr_bot = 0.0;
     float pos_buoy = 0.0;
-    float pos_buoy_last = 0.0;
+    float pos_buoy_max = 0.0;
     float pbot = sat_lyr.bottom;
     float buoy_bot = interp_pressure(sat_lyr.bottom, pres_arr, buoy_arr, N);
     float hbot = interp_pressure(sat_lyr.bottom, pres_arr, hght_arr, N);
     // set the LFC pressure to the LCL if the buoyancy is positive
     float lfc_pres = (buoy_bot > 0) ? sat_lyr.bottom : MISSING;
     float eql_pres = MISSING;
-    float lfc_pres_last = MISSING;
-    float eql_pres_last = MISSING;
+    float lfc_pres_final = MISSING;
+    float eql_pres_final = MISSING;
+    bool in_pos_area = (buoy_bot > 0);
 
     for (std::ptrdiff_t k = lyr_idx.kbot; k < lyr_idx.ktop + 1; ++k) {
 #ifndef NO_QC
@@ -99,54 +99,55 @@ void Parcel::find_lfc_el(const float pres_arr[], const float hght_arr[],
         const float htop = hght_arr[k];
         const float buoy_top = buoy_arr[k];
         const float lyr_top = (buoy_top + buoy_bot) / 2.0f;
-        // LFC condition
-        if ((lyr_bot <= 0) && (lyr_top > 0)) {
-            if (lfc_pres != MISSING) {
-                pos_buoy_last = pos_buoy;
-                lfc_pres_last = lfc_pres;
-                eql_pres_last = eql_pres;
-                pos_buoy = 0.0;
-            }
-            const float pres_start = std::min(this->lcl_pressure, pbot + 500);
-            const float pres_end = std::max(ptop - 500, pres_arr[N - 1]);
-            for (lfc_pres = pres_start; lfc_pres > pres_end;
-                 lfc_pres -= 100.0) {
-                const float buoy =
-                    interp_pressure(lfc_pres, pres_arr, buoy_arr, N);
-                if (buoy > 0) break;
-            }
+
+        if (!in_pos_area && (buoy_bot <= 0) && (buoy_top > 0)) {
+            pos_buoy = 0.0;
+            eql_pres = MISSING;
+            in_pos_area = true;
+
+            const float log_pbot = std::log10(pbot);
+            const float log_ptop = std::log10(ptop);
+            const float buoy_diff = buoy_top - buoy_bot;
+            const float log_pres_diff = log_ptop - log_pbot;
+            const float log_lfc_pres =
+                log_pbot - buoy_bot * (log_pres_diff / buoy_diff);
+            lfc_pres =
+                std::min(std::pow(10.0f, log_lfc_pres), this->lcl_pressure);
         }
 
-        // keep track of buoyancy so that we pick the max CAPE layer
-        const float condition = ((lfc_pres != MISSING) & (lyr_top > 0));
+        const float condition = ((in_pos_area) & (lyr_top > 0));
         pos_buoy += condition * lyr_top * (htop - hbot);
-        // EL condition
-        if ((lfc_pres != MISSING) && ((lyr_bot >= 0) && (lyr_top < 0))) {
-            const float pres_start = std::min(lfc_pres, pbot + 500);
-            const float pres_end = std::max(ptop - 500, pres_arr[N - 1]);
-            for (eql_pres = pres_start; eql_pres > pres_end;
-                 eql_pres -= 100.0) {
-                const float buoy =
-                    interp_pressure(eql_pres, pres_arr, buoy_arr, N);
-                if (buoy < 0) break;
-            }
-            if (pos_buoy_last > pos_buoy) {
-                lfc_pres = lfc_pres_last;
-                eql_pres = eql_pres_last;
-                pos_buoy = pos_buoy_last;
+
+        if (in_pos_area && ((buoy_bot >= 0) && (buoy_top < 0))) {
+            in_pos_area = false;
+            const float log_pbot = std::log10(pbot);
+            const float log_ptop = std::log10(ptop);
+            const float buoy_diff = buoy_top - buoy_bot;
+            const float log_pres_diff = log_ptop - log_pbot;
+            const float log_eql_pres =
+                log_pbot - buoy_bot * (log_pres_diff / buoy_diff);
+            eql_pres = std::max(std::pow(10.0f, log_eql_pres), pres_arr[N - 1]);
+            if (pos_buoy > pos_buoy_max) {
+                pos_buoy_max = pos_buoy;
+                lfc_pres_final = lfc_pres;
+                eql_pres_final = eql_pres;
             }
         }
-        // If there is no EL, just use the last available level
-        if ((k == N - 1) && (lyr_top > 0)) eql_pres = pres_arr[N - 1];
-        // set loop variables
         pbot = ptop;
         hbot = htop;
         buoy_bot = buoy_top;
-        lyr_bot = lyr_top;
     }
-    if (pos_buoy > 0.0f) {
-        this->lfc_pressure = lfc_pres;
-        this->eql_pressure = eql_pres;
+    if (in_pos_area) {
+        eql_pres = pres_arr[N - 1];
+        if (pos_buoy > pos_buoy_max) {
+            pos_buoy_max = pos_buoy;
+            lfc_pres_final = lfc_pres;
+            eql_pres_final = eql_pres;
+        }
+    }
+    if (pos_buoy_max > 0.0f) {
+        this->lfc_pressure = lfc_pres_final;
+        this->eql_pressure = eql_pres_final;
     }
 }
 

--- a/tests/python/test_interp.py
+++ b/tests/python/test_interp.py
@@ -61,6 +61,7 @@ def test_interp_pres():
 def test_find_first_pres():
     pres = np.arange(10000.0, 110000.0, 10000.0)[::-1]
     data = np.arange(1.0, 11.0, 1.0)
+    data[2] = constants.MISSING
 
     assert (interp.find_first_pressure(5.0, pres, data) == 60000.0)
     assert (interp.find_first_pressure(
@@ -71,11 +72,14 @@ def test_find_first_pres():
 
     assert (interp.find_first_pressure(
         constants.MISSING, pres, data) == constants.MISSING)
+    assert (interp.find_first_pressure(
+        3, pres, data) == pytest.approx(79372.6))
 
 
 def test_find_first_height():
     hght = np.arange(100.0, 1100.0, 100.0)
     data = np.arange(1.0, 11.0, 1.0)
+    data[2] = constants.MISSING
 
     assert (interp.find_first_height(5.0, hght, data) == 500.0)
     assert (interp.find_first_height(5.5, hght, data) == 550.0)
@@ -84,3 +88,4 @@ def test_find_first_height():
 
     assert (interp.find_first_height(
         constants.MISSING, hght, data) == constants.MISSING)
+    assert (interp.find_first_height(3, hght, data) == 300.0)

--- a/tests/python/test_params.py
+++ b/tests/python/test_params.py
@@ -224,7 +224,7 @@ def test_stp_scp_ship():
         esrh,
         ebwd
     )
-    assert (stp == pytest.approx(0.4849648, abs=1e-4))
+    assert (stp == pytest.approx(0.4851581, abs=1e-4))
 
     scp = params.supercell_composite_parameter(mupcl.cape, esrh, ebwd)
     assert (scp == pytest.approx(7.9699, abs=1e-1))
@@ -286,7 +286,7 @@ def test_ehi():
     )
 
     ehi = params.energy_helicity_index(pcl.cape, srh)
-    assert (ehi == pytest.approx(4.411969661))
+    assert (ehi == pytest.approx(4.412268638))
 
 
 def test_precipitable_water():

--- a/tests/python/test_params.py
+++ b/tests/python/test_params.py
@@ -78,7 +78,7 @@ def test_effective_inflow_layer_wobus():
     assert (eil.bottom == pytest.approx(92043.0))
     assert (eil.top == pytest.approx(83384.0))
     assert (mupcl.cape == pytest.approx(3353.4, abs=5e-1))
-    assert (mupcl.cinh == pytest.approx(-34.5697, abs=5e-4))
+    assert (mupcl.cinh == pytest.approx(-34.5707, abs=5e-4))
 
 
 def test_effective_inflow_layer_cm1():
@@ -140,8 +140,8 @@ def test_bunkers_motion():
         eil, mupcl
     )
 
-    assert (storm_mtn.u == pytest.approx(9.74783))
-    assert (storm_mtn.v == pytest.approx(5.570305))
+    assert (storm_mtn.u == pytest.approx(9.65811))
+    assert (storm_mtn.v == pytest.approx(5.558156))
 
 
 def test_stp_scp_ship():
@@ -224,7 +224,7 @@ def test_stp_scp_ship():
         esrh,
         ebwd
     )
-    assert (stp == pytest.approx(0.4851581, abs=1e-4))
+    assert (stp == pytest.approx(0.48329, abs=1e-4))
 
     scp = params.supercell_composite_parameter(mupcl.cape, esrh, ebwd)
     assert (scp == pytest.approx(7.9699, abs=1e-1))
@@ -286,7 +286,7 @@ def test_ehi():
     )
 
     ehi = params.energy_helicity_index(pcl.cape, srh)
-    assert (ehi == pytest.approx(4.412268638))
+    assert (ehi == pytest.approx(4.41228, abs=1e-5))
 
 
 def test_precipitable_water():

--- a/tests/python/test_params.py
+++ b/tests/python/test_params.py
@@ -202,7 +202,9 @@ def test_stp_scp_ship():
         snd_data["pres"],
         snd_data["hght"]
     )
-    ebwd_lyr = layer.HeightLayer(eil_hght.bottom, 0.5*eql_hght)
+    depth = (eql_hght - eil_hght.bottom)*0.5
+    ebwd_lyr = layer.HeightLayer(
+        eil_hght.bottom, float(eil_hght.bottom + depth))
     ebwd_cmp = winds.wind_shear(
         ebwd_lyr,
         snd_data["hght"],

--- a/tests/python/test_parcel.py
+++ b/tests/python/test_parcel.py
@@ -108,8 +108,8 @@ def test_surface_parcel():
 
     assert (cape == pytest.approx(3353.6, abs=1e-1))
     assert (cinh == pytest.approx(-34.5697, abs=1e-1))
-    assert (pcl.lfc_pressure == pytest.approx(71729.39, abs=1e-1))
-    assert (pcl.eql_pressure == pytest.approx(17933.91, abs=1e-1))
+    assert (pcl.lfc_pressure == pytest.approx(71729, abs=1e-0))
+    assert (pcl.eql_pressure == pytest.approx(17933, abs=1e-0))
 
     lifter = parcel.lifter_cm1()
     lifter.ma_type = thermo.adiabat.pseudo_liq
@@ -119,8 +119,8 @@ def test_surface_parcel():
 
     assert (cape == pytest.approx(3107.6, abs=5e-1))
     assert (cinh == pytest.approx(-36.4, abs=5e-1))
-    assert (pcl.lfc_pressure == pytest.approx(71482.05, abs=1e-1))
-    assert (pcl.eql_pressure == pytest.approx(18969.14, abs=1e-1))
+    assert (pcl.lfc_pressure == pytest.approx(71482, abs=1e-0))
+    assert (pcl.eql_pressure == pytest.approx(18969, abs=1e-0))
 
 
 def test_mixed_layer_parcel():
@@ -141,8 +141,8 @@ def test_mixed_layer_parcel():
 
     assert (cape == pytest.approx(2148.9, abs=1e-1))
     assert (cinh == pytest.approx(-128.49, abs=1e-1))
-    assert (pcl.lfc_pressure == pytest.approx(67505.7, abs=1e-1))
-    assert (pcl.eql_pressure == pytest.approx(20371.27, abs=1e-1))
+    assert (pcl.lfc_pressure == pytest.approx(67505, abs=1e-0))
+    assert (pcl.eql_pressure == pytest.approx(20371, abs=1e-0))
 
     lifter = parcel.lifter_cm1()
     vtmpk = pcl.lift_parcel(lifter, snd_data["pres"])
@@ -151,8 +151,8 @@ def test_mixed_layer_parcel():
 
     assert (cape == pytest.approx(1929.36, abs=5e-1))
     assert (cinh == pytest.approx(-133.71, abs=5e-1))
-    assert (pcl.lfc_pressure == pytest.approx(67100.015, abs=1e-1))
-    assert (pcl.eql_pressure == pytest.approx(20968.045, abs=1e-1))
+    assert (pcl.lfc_pressure == pytest.approx(67100, abs=1e-0))
+    assert (pcl.eql_pressure == pytest.approx(20968, abs=1e-0))
 
 
 def test_most_unstable_parcel():
@@ -177,8 +177,8 @@ def test_most_unstable_parcel():
     assert (pcl.dwpk == pytest.approx(291.532))
     assert (pcl.cape == pytest.approx(3353.6, abs=1e-1))
     assert (pcl.cinh == pytest.approx(-34.5697, abs=1e-1))
-    assert (pcl.lfc_pressure == pytest.approx(71729.39, abs=1e-1))
-    assert (pcl.eql_pressure == pytest.approx(17933.91, abs=1e-1))
+    assert (pcl.lfc_pressure == pytest.approx(71729, abs=1e-0))
+    assert (pcl.eql_pressure == pytest.approx(17933, abs=1e-0))
 
     lifter = parcel.lifter_cm1()
     lifter.ma_type = thermo.adiabat.pseudo_liq
@@ -198,5 +198,5 @@ def test_most_unstable_parcel():
     assert (pcl.dwpk == pytest.approx(291.532))
     assert (pcl.cape == pytest.approx(3107.6, abs=5e-1))
     assert (pcl.cinh == pytest.approx(-36.4, abs=5e-1))
-    assert (pcl.lfc_pressure == pytest.approx(71482.05, abs=1e-1))
-    assert (pcl.eql_pressure == pytest.approx(18969.14, abs=1e-1))
+    assert (pcl.lfc_pressure == pytest.approx(71482, abs=1e0))
+    assert (pcl.eql_pressure == pytest.approx(18969, abs=1e0))

--- a/tests/python/test_parcel.py
+++ b/tests/python/test_parcel.py
@@ -108,8 +108,8 @@ def test_surface_parcel():
 
     assert (cape == pytest.approx(3353.6, abs=1e-1))
     assert (cinh == pytest.approx(-34.5697, abs=1e-1))
-    assert (pcl.lfc_pressure == pytest.approx(71729.39, abs=1e-2))
-    assert (pcl.eql_pressure == pytest.approx(17933.91, abs=1e-2))
+    assert (pcl.lfc_pressure == pytest.approx(71729.39, abs=1e-1))
+    assert (pcl.eql_pressure == pytest.approx(17933.91, abs=1e-1))
 
     lifter = parcel.lifter_cm1()
     lifter.ma_type = thermo.adiabat.pseudo_liq
@@ -119,8 +119,8 @@ def test_surface_parcel():
 
     assert (cape == pytest.approx(3107.6, abs=5e-1))
     assert (cinh == pytest.approx(-36.4, abs=5e-1))
-    assert (pcl.lfc_pressure == pytest.approx(71482.05, abs=1e-2))
-    assert (pcl.eql_pressure == pytest.approx(18969.14, abs=1e-2))
+    assert (pcl.lfc_pressure == pytest.approx(71482.05, abs=1e-1))
+    assert (pcl.eql_pressure == pytest.approx(18969.14, abs=1e-1))
 
 
 def test_mixed_layer_parcel():
@@ -141,8 +141,8 @@ def test_mixed_layer_parcel():
 
     assert (cape == pytest.approx(2148.9, abs=1e-1))
     assert (cinh == pytest.approx(-128.49, abs=1e-1))
-    assert (pcl.lfc_pressure == pytest.approx(67505.7, abs=1e-2))
-    assert (pcl.eql_pressure == pytest.approx(20371.27, abs=1e-2))
+    assert (pcl.lfc_pressure == pytest.approx(67505.7, abs=1e-1))
+    assert (pcl.eql_pressure == pytest.approx(20371.27, abs=1e-1))
 
     lifter = parcel.lifter_cm1()
     vtmpk = pcl.lift_parcel(lifter, snd_data["pres"])
@@ -151,8 +151,8 @@ def test_mixed_layer_parcel():
 
     assert (cape == pytest.approx(1929.36, abs=5e-1))
     assert (cinh == pytest.approx(-133.71, abs=5e-1))
-    assert (pcl.lfc_pressure == pytest.approx(67100.015, abs=1e-2))
-    assert (pcl.eql_pressure == pytest.approx(20968.045, abs=1e-2))
+    assert (pcl.lfc_pressure == pytest.approx(67100.015, abs=1e-1))
+    assert (pcl.eql_pressure == pytest.approx(20968.045, abs=1e-1))
 
 
 def test_most_unstable_parcel():
@@ -177,8 +177,8 @@ def test_most_unstable_parcel():
     assert (pcl.dwpk == pytest.approx(291.532))
     assert (pcl.cape == pytest.approx(3353.6, abs=1e-1))
     assert (pcl.cinh == pytest.approx(-34.5697, abs=1e-1))
-    assert (pcl.lfc_pressure == pytest.approx(71729.39, abs=1e-2))
-    assert (pcl.eql_pressure == pytest.approx(17933.91, abs=1e-2))
+    assert (pcl.lfc_pressure == pytest.approx(71729.39, abs=1e-1))
+    assert (pcl.eql_pressure == pytest.approx(17933.91, abs=1e-1))
 
     lifter = parcel.lifter_cm1()
     lifter.ma_type = thermo.adiabat.pseudo_liq
@@ -198,5 +198,5 @@ def test_most_unstable_parcel():
     assert (pcl.dwpk == pytest.approx(291.532))
     assert (pcl.cape == pytest.approx(3107.6, abs=5e-1))
     assert (pcl.cinh == pytest.approx(-36.4, abs=5e-1))
-    assert (pcl.lfc_pressure == pytest.approx(71482.05, abs=1e-2))
-    assert (pcl.eql_pressure == pytest.approx(18969.14, abs=1e-2))
+    assert (pcl.lfc_pressure == pytest.approx(71482.05, abs=1e-1))
+    assert (pcl.eql_pressure == pytest.approx(18969.14, abs=1e-1))

--- a/tests/python/test_parcel.py
+++ b/tests/python/test_parcel.py
@@ -106,10 +106,10 @@ def test_surface_parcel():
     buoy = thermo.buoyancy(vtmpk, snd_data["vtmp"])
     cape, cinh = pcl.cape_cinh(snd_data["pres"], snd_data["hght"], buoy)
 
-    assert (cape == pytest.approx(3353.4, abs=1e-1))
+    assert (cape == pytest.approx(3353.6, abs=1e-1))
     assert (cinh == pytest.approx(-34.5697, abs=1e-1))
-    assert (pcl.lfc_pressure == 71250.0)
-    assert (pcl.eql_pressure == 17436.0)
+    assert (pcl.lfc_pressure == 71650.0)
+    assert (pcl.eql_pressure == 17836.0)
 
     lifter = parcel.lifter_cm1()
     lifter.ma_type = thermo.adiabat.pseudo_liq
@@ -119,8 +119,8 @@ def test_surface_parcel():
 
     assert (cape == pytest.approx(3107.6, abs=5e-1))
     assert (cinh == pytest.approx(-36.4, abs=5e-1))
-    assert (pcl.lfc_pressure == 70983.0)
-    assert (pcl.eql_pressure == 18439.0)
+    assert (pcl.lfc_pressure == 71383.0)
+    assert (pcl.eql_pressure == 18839.0)
 
 
 def test_mixed_layer_parcel():
@@ -139,10 +139,10 @@ def test_mixed_layer_parcel():
     buoy = thermo.buoyancy(vtmpk, snd_data["vtmp"])
     cape, cinh = pcl.cape_cinh(snd_data["pres"], snd_data["hght"], buoy)
 
-    assert (cape == pytest.approx(2148.6, abs=1e-1))
+    assert (cape == pytest.approx(2148.9, abs=1e-1))
     assert (cinh == pytest.approx(-128.49, abs=1e-1))
-    assert (pcl.lfc_pressure == pytest.approx(67018.0))
-    assert (pcl.eql_pressure == pytest.approx(19842.0))
+    assert (pcl.lfc_pressure == pytest.approx(67618.0))
+    assert (pcl.eql_pressure == pytest.approx(20242.0))
 
     lifter = parcel.lifter_cm1()
     vtmpk = pcl.lift_parcel(lifter, snd_data["pres"])
@@ -151,8 +151,8 @@ def test_mixed_layer_parcel():
 
     assert (cape == pytest.approx(1929.36, abs=5e-1))
     assert (cinh == pytest.approx(-133.71, abs=5e-1))
-    assert (pcl.lfc_pressure == pytest.approx(66648.0))
-    assert (pcl.eql_pressure == pytest.approx(20468.0))
+    assert (pcl.lfc_pressure == pytest.approx(67148.0))
+    assert (pcl.eql_pressure == pytest.approx(20968.0))
 
 
 def test_most_unstable_parcel():
@@ -175,10 +175,10 @@ def test_most_unstable_parcel():
     assert (pcl.pres == pytest.approx(92043.0))
     assert (pcl.tmpk == pytest.approx(298.15))
     assert (pcl.dwpk == pytest.approx(291.532))
-    assert (pcl.cape == pytest.approx(3353.4, abs=1e-1))
+    assert (pcl.cape == pytest.approx(3353.6, abs=1e-1))
     assert (pcl.cinh == pytest.approx(-34.5697, abs=1e-1))
-    assert (pcl.lfc_pressure == pytest.approx(71250.0, abs=1e-1))
-    assert (pcl.eql_pressure == pytest.approx(17436.0, abs=1e-1))
+    assert (pcl.lfc_pressure == pytest.approx(71650.0, abs=1e-1))
+    assert (pcl.eql_pressure == pytest.approx(17836.0, abs=1e-1))
 
     lifter = parcel.lifter_cm1()
     lifter.ma_type = thermo.adiabat.pseudo_liq
@@ -198,5 +198,5 @@ def test_most_unstable_parcel():
     assert (pcl.dwpk == pytest.approx(291.532))
     assert (pcl.cape == pytest.approx(3107.6, abs=5e-1))
     assert (pcl.cinh == pytest.approx(-36.4, abs=5e-1))
-    assert (pcl.lfc_pressure == pytest.approx(70983.0, abs=1e-1))
-    assert (pcl.eql_pressure == pytest.approx(18439.0, abs=1e-1))
+    assert (pcl.lfc_pressure == pytest.approx(71383.0, abs=1e-1))
+    assert (pcl.eql_pressure == pytest.approx(18839.0, abs=1e-1))

--- a/tests/python/test_parcel.py
+++ b/tests/python/test_parcel.py
@@ -108,8 +108,8 @@ def test_surface_parcel():
 
     assert (cape == pytest.approx(3353.6, abs=1e-1))
     assert (cinh == pytest.approx(-34.5697, abs=1e-1))
-    assert (pcl.lfc_pressure == 71650.0)
-    assert (pcl.eql_pressure == 17836.0)
+    assert (pcl.lfc_pressure == pytest.approx(71729.39, abs=1e-2))
+    assert (pcl.eql_pressure == pytest.approx(17933.91, abs=1e-2))
 
     lifter = parcel.lifter_cm1()
     lifter.ma_type = thermo.adiabat.pseudo_liq
@@ -119,8 +119,8 @@ def test_surface_parcel():
 
     assert (cape == pytest.approx(3107.6, abs=5e-1))
     assert (cinh == pytest.approx(-36.4, abs=5e-1))
-    assert (pcl.lfc_pressure == 71383.0)
-    assert (pcl.eql_pressure == 18839.0)
+    assert (pcl.lfc_pressure == pytest.approx(71482.05, abs=1e-2))
+    assert (pcl.eql_pressure == pytest.approx(18969.14, abs=1e-2))
 
 
 def test_mixed_layer_parcel():
@@ -141,8 +141,8 @@ def test_mixed_layer_parcel():
 
     assert (cape == pytest.approx(2148.9, abs=1e-1))
     assert (cinh == pytest.approx(-128.49, abs=1e-1))
-    assert (pcl.lfc_pressure == pytest.approx(67618.0))
-    assert (pcl.eql_pressure == pytest.approx(20242.0))
+    assert (pcl.lfc_pressure == pytest.approx(67505.7, abs=1e-2))
+    assert (pcl.eql_pressure == pytest.approx(20371.27, abs=1e-2))
 
     lifter = parcel.lifter_cm1()
     vtmpk = pcl.lift_parcel(lifter, snd_data["pres"])
@@ -151,8 +151,8 @@ def test_mixed_layer_parcel():
 
     assert (cape == pytest.approx(1929.36, abs=5e-1))
     assert (cinh == pytest.approx(-133.71, abs=5e-1))
-    assert (pcl.lfc_pressure == pytest.approx(67148.0))
-    assert (pcl.eql_pressure == pytest.approx(20968.0))
+    assert (pcl.lfc_pressure == pytest.approx(67100.015, abs=1e-2))
+    assert (pcl.eql_pressure == pytest.approx(20968.045, abs=1e-2))
 
 
 def test_most_unstable_parcel():
@@ -177,8 +177,8 @@ def test_most_unstable_parcel():
     assert (pcl.dwpk == pytest.approx(291.532))
     assert (pcl.cape == pytest.approx(3353.6, abs=1e-1))
     assert (pcl.cinh == pytest.approx(-34.5697, abs=1e-1))
-    assert (pcl.lfc_pressure == pytest.approx(71650.0, abs=1e-1))
-    assert (pcl.eql_pressure == pytest.approx(17836.0, abs=1e-1))
+    assert (pcl.lfc_pressure == pytest.approx(71729.39, abs=1e-2))
+    assert (pcl.eql_pressure == pytest.approx(17933.91, abs=1e-2))
 
     lifter = parcel.lifter_cm1()
     lifter.ma_type = thermo.adiabat.pseudo_liq
@@ -198,5 +198,5 @@ def test_most_unstable_parcel():
     assert (pcl.dwpk == pytest.approx(291.532))
     assert (pcl.cape == pytest.approx(3107.6, abs=5e-1))
     assert (pcl.cinh == pytest.approx(-36.4, abs=5e-1))
-    assert (pcl.lfc_pressure == pytest.approx(71383.0, abs=1e-1))
-    assert (pcl.eql_pressure == pytest.approx(18839.0, abs=1e-1))
+    assert (pcl.lfc_pressure == pytest.approx(71482.05, abs=1e-2))
+    assert (pcl.eql_pressure == pytest.approx(18969.14, abs=1e-2))

--- a/tests/unit/test_interp.cpp
+++ b/tests/unit/test_interp.cpp
@@ -120,11 +120,6 @@ TEST_CASE("Testing find_first_pressure") {
     CHECK(sharp::find_first_pressure(5.0f, pres_arr, data_arr2, N) == 50000.0f);
     CHECK(sharp::find_first_pressure(5.5f, pres_arr, data_arr2, N) ==
           doctest::Approx(54772.3f));
-
-#ifndef NO_WC
-    CHECK(sharp::find_first_pressure(sharp::MISSING, pres_arr, data_arr2, N) ==
-          sharp::MISSING);
-#endif
 }
 
 TEST_CASE("Testing find_first_height") {
@@ -138,9 +133,49 @@ TEST_CASE("Testing find_first_height") {
     CHECK(sharp::find_first_height(5.5f, hght_arr, data_arr1, N) == 550.0f);
     CHECK(sharp::find_first_height(5, hght_arr, data_arr2, N) == 600.0f);
     CHECK(sharp::find_first_height(5.5f, hght_arr, data_arr2, N) == 550.0f);
+}
 
 #ifndef NO_QC
+TEST_CASE("Testing find_first_height_with_missing") {
+    constexpr std::ptrdiff_t N = 10;
+    constexpr float hght_arr[N] = {100, 200, 300, 400, 500,
+                                   600, 700, 800, 900, 1000};
+    constexpr float data_arr1[N] = {1, 2, sharp::MISSING, 4, 5, 6, 7, 8, 9, 10};
+    constexpr float data_arr2[N] = {10, 9, sharp::MISSING, 7, 6, 5, 4, 3, 2, 1};
+
+    CHECK(sharp::find_first_height(5, hght_arr, data_arr1, N) == 500.0f);
+    CHECK(sharp::find_first_height(5.5f, hght_arr, data_arr1, N) == 550.0f);
+    CHECK(sharp::find_first_height(5, hght_arr, data_arr2, N) == 600.0f);
+    CHECK(sharp::find_first_height(5.5f, hght_arr, data_arr2, N) == 550.0f);
+
     CHECK(sharp::find_first_height(sharp::MISSING, hght_arr, data_arr1, N) ==
           sharp::MISSING);
-#endif
+    CHECK(sharp::find_first_height(3, hght_arr, data_arr1, N) == 300.0);
+    CHECK(sharp::find_first_height(8, hght_arr, data_arr2, N) == 300.0);
 }
+#endif
+
+#ifndef NO_QC
+TEST_CASE("Testing find_first_pressure_with_missing") {
+    constexpr std::ptrdiff_t N = 10;
+    // pressure is always in Pa
+    constexpr float pres_arr[N] = {100000, 90000, 80000, 70000, 60000,
+                                   50000,  40000, 30000, 20000, 10000};
+    constexpr float data_arr1[N] = {1, 2, sharp::MISSING, 4, 5, 6, 7, 8, 9, 10};
+    constexpr float data_arr2[N] = {10, 9, sharp::MISSING, 7, 6, 5, 4, 3, 2, 1};
+
+    CHECK(sharp::find_first_pressure(5.0f, pres_arr, data_arr1, N) == 60000.0f);
+    CHECK(sharp::find_first_pressure(5.5f, pres_arr, data_arr1, N) ==
+          doctest::Approx(54772.3f));
+    CHECK(sharp::find_first_pressure(5.0f, pres_arr, data_arr2, N) == 50000.0f);
+    CHECK(sharp::find_first_pressure(5.5f, pres_arr, data_arr2, N) ==
+          doctest::Approx(54772.3f));
+
+    CHECK(sharp::find_first_pressure(sharp::MISSING, pres_arr, data_arr2, N) ==
+          sharp::MISSING);
+    CHECK(sharp::find_first_pressure(3.0f, pres_arr, data_arr1, N) ==
+          doctest::Approx(79372.6f));
+    CHECK(sharp::find_first_pressure(8.0f, pres_arr, data_arr2, N) ==
+          doctest::Approx(79372.6f));
+}
+#endif


### PR DESCRIPTION
* Fixed a bug in `lift_parcel` leftover from when it returned buoyancy instead of parcel virtual temperature. The parcel virtual temperature array is now filled with `sharp::MISSING` instead of `0.0` for below-LPL values. (#46)
* Fixed undefined behavior in `find_first_pressure` and `find_first_height`to now properly handle `sharp::MISSING` (#46).
* Fixed erroneous behavior in `find_lfc_el` that would result in incorrect LFC and EL pressures (#52, #53).
    * LFC/EL condition check now happens on the raw buoyancy values, rather than the layer-average buoyancy. The layer-average buoyancy was a holdover from NSHARP and when parcel lifting and integration happened within the same loop. It was also used to address small LFC-EL detections aloft. Since this search looks for the max CAPE by an LFC-EL pair, this is less susceptible to this problem -- though, in some circumstances, could result in a lower EL height. 
    * The previous logic only compared adjacent layers for the max buoyancy -- new version considers the whole profile.
    * The previous logic performed a search for the LFC/EL by performing an interpolation loop in `1 hPa` increments. This caused a few issues with incomplete sounding profiles, and could also result in an LFC below the LCL, or an EL above the top of the available data. Moving to the raw buoyancy for detection helps eliminate the need for this, and linear interpolation is used to detect the zero-crossings. 

Changes to LFC and EL pressures (and the impacts on derived variables) were tested against a known dataset of soundings, and did not show any unexpected or alarming differences, nor major shifts in things like STP. 