### PR TITLE
Configurable iterative solver convergence criteria for Wobus saturated ascent (#59)

### DIFF
--- a/include/SHARPlib/parcel.h
+++ b/include/SHARPlib/parcel.h
@@ -47,6 +47,11 @@ struct lifter_wobus {
     static constexpr bool lift_from_lcl = true;
 
     /**
+     * \brief The iterative convergence criteria (K)
+     */
+    float converge = 0.001f;
+
+    /**
      * \brief Perform the setup step for the parcel lifter.
      *
      * Some parcel lifters require setup in order to handle
@@ -67,7 +72,7 @@ struct lifter_wobus {
      */
     [[nodiscard]] inline float operator()(const float pres, const float tmpk,
                                           const float new_pres) const {
-        return wetlift(pres, tmpk, new_pres);
+        return wetlift(pres, tmpk, new_pres, converge);
     }
 
     /**
@@ -102,7 +107,23 @@ struct lifter_wobus {
  * the parcel lifting algorithm to their specifications.
  */
 struct lifter_cm1 {
-   private:
+    static constexpr bool lift_from_lcl = false;
+
+    /**
+     * \brief The type of moist adiabat to use, as defined by sharp::adiabat
+     */
+    adiabat ma_type = adiabat::pseudo_liq;
+
+    /**
+     * \brief The pressure increment (Pa) to use for the iterative solver
+     */
+    float pressure_incr = 500.0f;
+
+    /**
+     * \brief The iterative convergence criteria (K)
+     */
+    float converge = 0.001f;
+
     /**
      * \brief Used to keep track of mixing ratio for conserved/adiabatic lifting
      */
@@ -122,24 +143,6 @@ struct lifter_cm1 {
      * \brief Ice water mixing ratio variable updated during parcel lifts
      */
     float ri = MISSING;
-
-   public:
-    static constexpr bool lift_from_lcl = false;
-
-    /**
-     * \brief The type of moist adiabat to use, as defined by sharp::adiabat
-     */
-    adiabat ma_type = adiabat::pseudo_liq;
-
-    /**
-     * \brief The pressure increment (Pa) to use for the iterative solver
-     */
-    float pressure_incr = 500.0f;
-
-    /**
-     * \brief The iterative convergence criteria (K)
-     */
-    float converge = 0.001f;
 
     /**
      * \brief perform the necessary setup for parcel ascent.

--- a/include/SHARPlib/thermo.h
+++ b/include/SHARPlib/thermo.h
@@ -347,16 +347,19 @@ enum class adiabat : int {
  * This function relies on the Wobus Function ( sharp::wobf ), and it was shown
  * by Robert Davies-Jones (2007) that the Wobus function has a slight
  * dependence on pressure, which results in errors of up to 1.2 Kelvin
- * in the temperature of a lifted parcel.
+ * in the temperature of a lifted parcel. This function also takes an optional
+ * argument that defines the iterative convergence criteria for the solver
+ * (default: 0.001 K).
  *
  * \param    pressure              (Pa)
  * \param    temperature           (K)
  * \param    lifted_pressure       (Pa)
+ * \param    converge              (K)
  *
  * \return   lifted_temperature    (K)
  */
 [[nodiscard]] float wetlift(float pressure, float temperature,
-                            float lifted_pressure);
+                            float lifted_pressure, float converge = 0.001f);
 
 /**
  * \author Kelton Halbert - NWS Storm Prediction Center

--- a/src/SHARPlib/thermo.cpp
+++ b/src/SHARPlib/thermo.cpp
@@ -214,7 +214,8 @@ float saturated_lift(float pressure, float theta_sat, float converge) {
     return t2 - eor;
 }
 
-float wetlift(float pressure, float temperature, float lifted_pressure) {
+float wetlift(float pressure, float temperature, float lifted_pressure,
+              float converge) {
 #ifndef NO_QC
     if ((temperature == MISSING) || (pressure == MISSING) ||
         (lifted_pressure == MISSING)) {
@@ -231,7 +232,7 @@ float wetlift(float pressure, float temperature, float lifted_pressure) {
     const float pcl_thetaw = pcl_theta - woth + wott;
     // get the temperature that crosses the moist adiabat at
     // this pressure level
-    return saturated_lift(lifted_pressure, pcl_thetaw);
+    return saturated_lift(lifted_pressure, pcl_thetaw, converge);
 }
 
 float _solve_cm1(float& pcl_pres_next, float& pcl_pi_next, float& pcl_t_next,

--- a/src/nanobind/parcel_bindings.h
+++ b/src/nanobind/parcel_bindings.h
@@ -43,6 +43,9 @@ configure the parcel lifting algorithm to their specifications.
                        R"pbdoc(
 A static flag that helps the parcel lifting functions know where to lift from.
 )pbdoc")
+        .def_rw("converge", &sharp::lifter_wobus::converge, R"pbdoc(
+The iterative convergence criteria (K)
+             )pbdoc")
         .def("setup", &sharp::lifter_wobus::setup, nb::arg("lcl_pres"),
              nb::arg("lcl_tmpk"), R"pbdoc(
 Some parcel lifters require setup in order to handle adiabatic ascent

--- a/src/nanobind/thermo_bindings.h
+++ b/src/nanobind/thermo_bindings.h
@@ -943,6 +943,7 @@ numpy.ndarray[dtype=float32]
 
     m_therm.def("wetlift", &sharp::wetlift, nb::arg("pressure"),
         nb::arg("temperature"), nb::arg("lifted_pressure"),
+        nb::arg("converge") = 0.001f,
         R"pbdoc(
 Compute the temperature of a parcel lifted moist adiabatically to a new level. 
 
@@ -963,6 +964,8 @@ temperature : float
     The saturated air temperature (K)
 lifted_pressure : float 
     The new pressure level to lift to (Pa)
+converge : float 
+    The iterative convergence criteria (K; default = 0.001)
 
 Returns
 -------


### PR DESCRIPTION
This PR exposes the iterative convergence criteria for the Wobus pseudoadiabatic ascent as a configurable parameter in `lifter_wobus`. There is no API breakage here via the use of default arguments. 