### PR TITLE
Undefined Equilibrium Levels return sharp::MISSING (#69)

### DIFF
--- a/include/SHARPlib/parcel.h
+++ b/include/SHARPlib/parcel.h
@@ -392,6 +392,12 @@ struct Parcel {
      * and EL are found, the values are set in sharp::Parcel::lfc_pres and
      * sharp::Parcel::eql_pres.
      *
+     * The value of sharp::Parcel::eql_pres is sharp::MISSING if there there
+     * is no qualifying level found within the data bounds (e.g. incomplete
+     * data, or an EL above the available data). Any calls to
+     * sharp::Parcel::cape_cinh will still compute CAPE without the presence of
+     * an EL, using the best-available data.
+     *
      * \param   pres_arr    The pressure coordinate array (Pa)
      * \param   hght_arr    The height coordinate array (meters)
      * \param   buoy_arr    The profile buoyancy array (m/s^2)
@@ -444,6 +450,13 @@ struct Parcel {
      * Assuming that sharp::Parcel::lift_parcel has been called, cape_cinh
      * will integrate the area between the LFC and EL to compute CAPE,
      * and integrate the area between the LPL and LCL to compute CINH.
+     *
+     * If sharp::Parcel::eql_pressure is sharp::MISSING, but the
+     * sharp::Parcel::lfc_pressure is defined, the routine will
+     * compute CAPE with the available data despite the lack of
+     * a defined equilibrium level. This is useful for incomplete
+     * profile data, or pressure-level data where the EL is above
+     * the top pressure value.
      *
      * The results are set in pcl->cape and pcl->cinh.
      *

--- a/src/SHARPlib/parcel.cpp
+++ b/src/SHARPlib/parcel.cpp
@@ -139,7 +139,7 @@ void Parcel::find_lfc_el(const float pres_arr[], const float hght_arr[],
         buoy_bot = buoy_top;
     }
     if (in_pos_area) {
-        eql_pres = pres_arr[N - 1];
+        eql_pres = MISSING;
         if (pos_buoy > pos_buoy_max) {
             pos_buoy_max = pos_buoy;
             lfc_pres_final = lfc_pres;
@@ -225,8 +225,13 @@ void Parcel::cape_cinh(const float pres_arr[], const float hght_arr[],
                        const float buoy_arr[], const ptrdiff_t N) {
     if (this->lcl_pressure == MISSING) return;
     find_lfc_el(pres_arr, hght_arr, buoy_arr, N);
-    if ((this->lfc_pressure != MISSING) && (this->eql_pressure != MISSING)) {
-        PressureLayer lfc_el = {this->lfc_pressure, this->eql_pressure};
+    if (this->lfc_pressure != MISSING) {
+        PressureLayer lfc_el = {MISSING, MISSING};
+        if (this->eql_pressure == MISSING) {
+            lfc_el = {this->lfc_pressure, pres_arr[N - 1]};
+        } else {
+            lfc_el = {this->lfc_pressure, this->eql_pressure};
+        }
         PressureLayer lpl_lfc = {this->pres, this->lfc_pressure};
         HeightLayer lfc_el_ht =
             pressure_layer_to_height(lfc_el, pres_arr, hght_arr, N);

--- a/src/nanobind/parcel_bindings.h
+++ b/src/nanobind/parcel_bindings.h
@@ -313,6 +313,12 @@ Once the LFC and EL are found, the value are set in
 nwsspc.sharp.calc.parcel.Parcel.lfc_pres and 
 nwsspc.sharp.calc.parcel.Parcel.eql_pres via the provided parcel.
 
+The value of eql_pres is MISSING if there is no qualifying level 
+found within the data bounds (e.g. incomplete data, or EL above 
+the available data). Any calls to nwsspc.sharp.calc.parcel.Parcel.cape_cinh 
+will still compute CAPE without the presence of an EL, using the best-available
+data. 
+
 Parameters
 ----------
 pressure : numpy.ndarray[dtype=float32] 
@@ -398,6 +404,12 @@ Assuming that nwsspc.sharp.calc.parcel.Parcel.lift_parcel has
 been called, cape_cinh will integrate the area between the LFC 
 and EL to compute CAPE, and integrate the area between the LPL 
 and LCL to compute CINH.
+
+If eql_pressure is MISSING, but lfc_pressure is defined, the 
+routine will compute CAPE with the available data despite the 
+lack of a defined equilibrium level. This is useful for 
+incomplete profile data, or pressure-level data where the EL 
+is above the top pressure value.
 
 The results are stored in nwsspc.sharp.calc.parcel.Parcel.cape 
 and nwsspc.sharp.calc.parcel.Parcel.cinh via the provided parcel.


### PR DESCRIPTION
This PR makes it so that the Equilibrium Level return `sharp::MISSING` if it is not found within the available data, rather than returning the last available level. 

The `sharp::Parcel::cape_cinh` routine will still compute best-available CAPE if EL is missing. This is considered a bug fix and not a breaking change since other derived parameters already require the checking of the EL for missing values (e.g. computing STP, effective bulk shear, parcel-based bunkers storm motion).

Closes #69 